### PR TITLE
The tcp_closed msg is missed

### DIFF
--- a/src/mysql.app.src
+++ b/src/mysql.app.src
@@ -18,7 +18,7 @@
 
 {application, mysql, [
     {description, "MySQL/OTP - Erlang MySQL client driver"},
-    {vsn, "1.7.0"},
+    {vsn, "1.7.2"},
     {modules, []},
     {registered, []},
     {applications, [kernel,stdlib,ssl]}

--- a/src/mysql.appup.src
+++ b/src/mysql.appup.src
@@ -1,0 +1,16 @@
+%% -*- mode: erlang -*-
+%% Unless you know what you are doing, DO NOT edit manually!!
+{"1.7.2",
+  [{<<"1\\.7\\.[0-1]">>,
+    [{load_module,mysql_protocol,brutal_purge,soft_purge,[]},
+     {load_module,mysql_conn,brutal_purge,soft_purge,[]}
+    ]},
+   {<<".*">>,[]}
+  ],
+  [{<<"1\\.7\\.[0-1]">>,
+    [{load_module,mysql_protocol,brutal_purge,soft_purge,[]},
+     {load_module,mysql_conn,brutal_purge,soft_purge,[]}
+    ]},
+   {<<".*">>,[]}
+  ]
+}.


### PR DESCRIPTION
When the MySQL server send us an error msg like `Code: 4031, SQLState: #HY000` (see the comments in the code), we should `setopts(SockMod, Socket, [{active, once}])` again.