### PR TITLE
Return more info in connection init errores

### DIFF
--- a/.ci/my-otp.cnf
+++ b/.ci/my-otp.cnf
@@ -1,2 +1,3 @@
 [mysqld]
 local_infile=ON
+mysql_native_password=ON

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        otp: [24, 25]
+        otp: [25, 26]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v3

--- a/src/mysql_conn.erl
+++ b/src/mysql_conn.erl
@@ -129,7 +129,12 @@ init(Opts) ->
                 {ok, State1} ->
                     {ok, State1};
                 {error, Reason} ->
-                    {stop, Reason}
+                    {stop, #{cause => Reason,
+                             host => Host,
+                             port => Port,
+                             database => Database,
+                             user => User
+                            }}
             end;
         asynchronous ->
             gen_server:cast(self(), connect),
@@ -505,12 +510,19 @@ handle_call(commit, {FromPid, _},
     {reply, ok, State1#state{transaction_levels = L}}.
 
 %% @private
-handle_cast(connect, #state{socket = undefined} = State) ->
+handle_cast(connect, #state{socket = undefined, host = Host, port = Port,
+                            user = User, database = Database
+                           } = State) ->
     case connect(State) of
         {ok, State1} ->
             {noreply, State1};
-        {error, _} = E ->
-            {stop, E, State}
+        {error, Reason} ->
+            {stop, #{cause => Reason,
+                     host => Host,
+                     port => Port,
+                     user => User,
+                     database => Database
+                    }, State}
     end;
 handle_cast(connect, State) ->
     {noreply, State};

--- a/src/mysql_encode.erl
+++ b/src/mysql_encode.erl
@@ -49,8 +49,8 @@ encode({D, {H, M, S}}) when D < 0, is_integer(S) ->
     end;
 encode({D, {H, M, S}}) when D < 0, is_float(S) ->
     SInt = trunc(S), % trunc(57.654321) = 57
-    {SInt1, Frac} = case S - SInt of % 57.6543 - 57 = 0.654321
-        0.0  -> {SInt, 0.0};
+    {SInt1, Frac} = case abs(S - SInt) of % 57.6543 - 57 = 0.654321
+        +0.0  -> {SInt, 0.0};
         Rest -> {SInt + 1, 1 - Rest} % {58, 0.345679}
     end,
     Sec = (D * 24 + H) * 3600 + M * 60 + SInt1,

--- a/src/mysql_protocol.erl
+++ b/src/mysql_protocol.erl
@@ -1132,7 +1132,7 @@ encode_param({D, {H, M, S}}) when is_float(S), S > 0.0, D < 0 ->
     Seconds = (D * 24 + H) * 3600 + M * 60 + IntS + 1,
     {D1, {M1, H1, S1}} = calendar:seconds_to_daystime(-Seconds),
     {<<?TYPE_TIME, 0>>, <<12, 1, D1:32/little, H1, M1, S1, Micro:32/little>>};
-encode_param({D, {H, M, 0.0}}) ->
+encode_param({D, {H, M, V}}) when abs(V) =:= +0.0 ->
     encode_param({D, {H, M, 0}}).
 
 %% @doc Checks if the given Parameters can be encoded for use in the


### PR DESCRIPTION
When there are more than one set of MySQL configs, it's quite hard to tell which one is for which.
before: `timeout`
after: `#{cause => timeout,port => 3306,user => <<"root">>,host => "1.1.1.1",database => <<"test">>}`

e.g.

2024-10-07T07:12:52.857393+00:00 [error] crasher: initial call: mysql_conn:init/1, pid: <0.6494.0>, registered_name: [], exit: {#{cause => timeout,port => 3306,user => <<"root">>,host => "1.1.1.1",database => <<"test">>},[{gen_server,init_it,6,[{file,"gen_server.erl"},{line,961}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,241}]}]}, ancestors: [<0.6493.0>,<0.6492.0>,<0.6490.0>,ecpool_sup,<0.4205.0>], message_queue_len: 0, messages: [], links: [<0.6493.0>], dictionary: [], trap_exit: false, status: running, heap_size: 376, stack_size: 28, reductions: 286; neighbours: