### PR TITLE
feat:support oceanbase

### DIFF
--- a/src/mysql_protocol.erl
+++ b/src/mysql_protocol.erl
@@ -109,7 +109,7 @@ handshake_finish_or_switch_auth(Handshake, Password, SockModule, Socket, SeqNum)
         #ok{status = OkStatus} ->
             %% check status, ignoring bit 16#4000, SERVER_SESSION_STATE_CHANGED
             %% and bit 16#0002, SERVER_STATUS_AUTOCOMMIT.
-            BitMask = bnot (?SERVER_SESSION_STATE_CHANGED bor ?SERVER_STATUS_AUTOCOMMIT),
+            BitMask = bnot (?SERVER_SESSION_STATE_CHANGED bor ?SERVER_STATUS_AUTOCOMMIT bor ?SERVER_MORE_RESULTS_EXISTS),
             StatusMasked = Status band BitMask,
             StatusMasked = OkStatus band BitMask,
             {ok, Handshake, SockModule, Socket};


### PR DESCRIPTION
Referring the mysql documentation and the golang mysql library, should be add use SERVER_MORE_RESULTS_EXISTS.
https://github.com/go-sql-driver/mysql
![image](https://github.com/user-attachments/assets/4f4dd0aa-0684-4c34-9d6b-084c4ea3b2a0)
